### PR TITLE
Fix delete refund

### DIFF
--- a/controllers/payppaypalpluswebhook.php
+++ b/controllers/payppaypalpluswebhook.php
@@ -287,7 +287,7 @@ class paypPayPalPlusWebhook extends oxUBase
     {
         /** @var paypPayPalPlusNoPaymentFoundException $oEx */
         $oEx = $this->getShop()->getNew('paypPayPalPlusNoPaymentFoundException');
-        $sMessage = $this->getShop()->translate('payp_PAYPALPLUS_ERROR_NO_PAYMENT_FOUND_FOR_EVENT');
+        $sMessage = $this->getShop()->translate('PAYP_PAYPALPLUS_ERROR_NO_PAYMENT_FOUND_FOR_EVENT');
         $oEx->setMessage($sMessage);
         throw $oEx;
     }
@@ -329,7 +329,7 @@ class paypPayPalPlusWebhook extends oxUBase
     {
         /** @var paypPayPalPlusPaymentDataSaveException $oEx */
         $oEx = $this->getShop()->getNew('paypPayPalPlusPaymentDataSaveException');
-        $sMessage = $this->getShop()->translate('payp_PAYPALPLUS_ERROR_PAYMENT_DATA_NOT_SAVED');
+        $sMessage = $this->getShop()->translate('PAYP_PAYPALPLUS_ERROR_PAYMENT_DATA_NOT_SAVED');
         $oEx->setMessage($sMessage);
         throw $oEx;
     }

--- a/core/payppaypalplusevents.php
+++ b/core/payppaypalplusevents.php
@@ -565,7 +565,7 @@ class paypPayPalPlusEvents extends paypPayPalPlusSuperCfg
         $sSecret = $oPayPalConfig->getSecret();
 
         if (empty($sClientId) || empty($sSecret)) {
-            $sMessage = $this->getShop()->translate('payp_PAYPALPLUS_ERROR_NO_USER_CREDENTIALS');
+            $sMessage = $this->getShop()->translate('PAYP_PAYPALPLUS_ERROR_NO_USER_CREDENTIALS');
             /** @var oxException $oException */
             $oException = oxNew('oxException');
             $oException->setMessage($sMessage);

--- a/models/payppaypalplusrefunddata.php
+++ b/models/payppaypalplusrefunddata.php
@@ -219,8 +219,6 @@ class paypPayPalPlusRefundData extends oxBase
             $oDb->quote($sSaleId)
         );
 
-        $oDb->execute($sDeleteQuery);
-
-        return (bool) $oDb->affected_Rows();
+        return (bool) $oDb->execute($sDeleteQuery);
     }
 }


### PR DESCRIPTION
Replaced removed method Affected_Rows().
This mehtod was removed in OXID 6:
>since v5.3.0 (2016-04-14); This method will be removed in v6.0. Use the return value of execute() instead.