### PR TITLE
Fix admin order sorting functionality

### DIFF
--- a/controllers/admin/admin_payppaypalplusorder_list.php
+++ b/controllers/admin/admin_payppaypalplusorder_list.php
@@ -94,7 +94,9 @@ class Admin_paypPayPalPlusOrder_List extends Admin_paypPayPalPlusOrder_List_pare
             LEFT JOIN payppaypalpluspui ON payppaypalpluspui.OXPAYMENTID = payppaypalpluspayment.OXPAYMENTID
         ";
 
-        $sSql = str_replace('from oxorder', $sQ, $sSql);
+        $unquoted = 'oxorder';
+        $quoted = oxDb::getDb()->quoteIdentifier('oxorder');
+        $sSql = preg_replace("/\bfrom\s+(?:\b$unquoted\b|$quoted)/i", $sQ, $sSql);
 
         return $sSql;
     }
@@ -114,7 +116,7 @@ class Admin_paypPayPalPlusOrder_List extends Admin_paypPayPalPlusOrder_List_pare
         $aSorting = parent::getListSorting();
         if ($aSorting['oxorder']['oxpaymenttype']) {
             $sQ = ' ORDER BY payments_oxdesc, IF(ISNULL(payppaypalpluspui_oxid), 0, 1), oxorder.oxbillnr, ';
-            $sSql = str_replace('order by ', $sQ, $sSql);
+            $sSql = str_ireplace('order by ', $sQ, $sSql);
         }
 
         return $sSql;


### PR DESCRIPTION
Due to a missing query API privided by OXID, SQL strings need to be manipulated directly in admin list controllers.
However, this is very error prone if multiple modules do this. For example one could replace "from oxorder" with "FROM OXORDER" or "from `oxorder`" (using MySQL identifier quoting (backticks)). All this results in valid SQL and should be considered to make the extension of the sql string more robust.

For example, the oxid paypal module replaces the unqoted `from oxorder` with a quoted table name:
https://github.com/OXID-eSales/paypal/blob/eb1392f37f34fec5a477d7319cad12aba35722fe/Controller/Admin/OrderList.php#L72

Currently, clicking the admin orders' "sort by payment column" link crashes when the SQL FROM clause is not exactly of the form `from oxorder`.
Because in that case, the joins are not applied and the order by statement extensions in `_prepareOrderByQuery()` use columns that can not be found.

The provided solution makes the extension more robust against different valid sql strings so that clicking the sorting link does not crash.

It works with variants like
* from oxorder
* FROM OXORDER
* FROM   oxorder
* FROM `oxorder`
* ...

Further it uses `str_ireplace` as case-insensitive replacement method to be more robust against valid variations.